### PR TITLE
Don't grow options table container to contents

### DIFF
--- a/org/kmallan/azureus/rssfeed/View.java
+++ b/org/kmallan/azureus/rssfeed/View.java
@@ -350,9 +350,9 @@ public class View implements MouseListener, SelectionListener, MenuListener, Mod
     tabOptions.setControl(options);
 
     // Options Folder - Tables
-    ScrolledComposite optValTblScrollComp = new ScrolledComposite(options, SWT.V_SCROLL | SWT.H_SCROLL | SWT.BORDER);
+    ScrolledComposite optValTblScrollComp = new ScrolledComposite(options, SWT.V_SCROLL | SWT.BORDER);
     layout = new GridLayout();
-    layoutData = new GridData(GridData.FILL_VERTICAL);
+    layoutData = new GridData(GridData.FILL_VERTICAL | GridData.FILL_HORIZONTAL);
     layoutData.widthHint = 380;
     optValTblScrollComp.setLayout(layout);
     optValTblScrollComp.setLayoutData(layoutData);
@@ -426,8 +426,6 @@ public class View implements MouseListener, SelectionListener, MenuListener, Mod
     btnFiltCopy = setupToolItem(filtCompBar, "Copy.gif");
     btnFiltRemove = setupToolItem(filtCompBar, "ItemRemove.gif");
     btnFiltDown = setupToolItem(filtCompBar, "ItemMoveDown.gif");
-
-    optValTblScrollComp.setMinSize(optValTblComp.computeSize(SWT.DEFAULT, SWT.DEFAULT));
 
     // Options Folder - Params
     optParamScrollComp = new ScrolledComposite(options, SWT.V_SCROLL | SWT.BORDER);


### PR DESCRIPTION
I've been having a problem for a while with the Options view, where the toolbars for the tables on the left side wouldn't show up because they were scrolled out of view.

Turns out, the ScrolledComposite container which holds all of those elements was being expanded to have its `minSize` equal the size of its contents, which is maybe not the best thing when dealing with tables that can have very wide columns (either intentionally or purely by accident). Once the table columns were widened, the container would expand, but it wouldn't later shrink down again even if the table itself were made narrower.

I'm not convinced that container should be a <code><i>Scrolled</i>Composite</code> at all, since having it scroll is never really desirable. (The tables' contents will scroll, which is correct and proper.) Nevertheless, to keep things simple I didn't change that, just set it up to only scroll vertically (same as the other column in that tab), and removed the line that computed an excessive `minSize` for it. Works For Me™ on Linux.